### PR TITLE
Add support for langdale

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-openbouffalo = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-openbouffalo = "8"
 
 LAYERDEPENDS_meta-openbouffalo = "meta-bl808"
-LAYERSERIES_COMPAT_meta-openbouffalo = "kirkstone"
+LAYERSERIES_COMPAT_meta-openbouffalo = "kirkstone langdale"


### PR DESCRIPTION
This just lets us run off of the branch recommended on the the main oelinux page. The meta-bl808 layer is already configured to work with langdale so I presume this is just on oversight.